### PR TITLE
Specify legacy-v0 branch for dsdl submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "dsdl"]
 	path = dsdl
 	url = https://github.com/UAVCAN/dsdl
+	branch = legacy-v0
 [submodule "libuavcan/dsdl_compiler/pyuavcan"]
 	path = libuavcan/dsdl_compiler/pyuavcan
 	url = https://github.com/UAVCAN/pyuavcan


### PR DESCRIPTION
The PX4/libuavcan "px4" branch is tracked to DSDL commit 192295c. This commit is not present in the "master" branch for DSDL, but is present in the "legacy-v0" branch.